### PR TITLE
Prevent resizing below the base window size

### DIFF
--- a/wireframe.py
+++ b/wireframe.py
@@ -11,7 +11,7 @@ class WireframeGUI:
         self.root = root
         self.root.title("Wireframe to Saber Converter")
         self.root.geometry("600x750")
-        self.root.minsize(600, 750) # Prevent resizing below the base window size, before the elements were easily cutoff when resized
+        self.root.minsize(600, 750) # Prevent resizing below the base window size to avoid cutting off interface elements
 
         # Variables to store user inputs
         self.infile_path = tk.StringVar()

--- a/wireframe.py
+++ b/wireframe.py
@@ -11,6 +11,7 @@ class WireframeGUI:
         self.root = root
         self.root.title("Wireframe to Saber Converter")
         self.root.geometry("600x750")
+        self.root.minsize(600, 750) # Prevent resizing below the base window size, before the elements were easily cutoff when resized
 
         # Variables to store user inputs
         self.infile_path = tk.StringVar()


### PR DESCRIPTION
This change ensures that the window cannot be resized below its base size, preventing interface elements from being cut off.